### PR TITLE
[metadata] Remove profiled dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ See [`metadata.json`](metadata.json). In particular, this module depends on
 * [puppetlabs/stdlib](https://forge.puppetlabs.com/puppetlabs/stdlib)
 * [puppetlabs/vcsrepo](https://forge.puppetlabs.com/puppetlabs/vcsrepo)
 * [puppetlabs/concat](https://forge.puppetlabs.com/puppetlabs/concat)
-* [unibet/profiled](https://forge.puppetlabs.com/unibet/profiled)
 
 ## Overview and Usage
 

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -14,10 +14,6 @@ class bash::common {
     # Load the variables used in this module. Check the params.pp file
     require bash::params
 
-    if !defined(Class['profiled']) {
-      include profiled
-    }
-
     package { 'bash':
         ensure => 'present',   # You shall NEVER remove the bash package
         name   => $bash::params::packagename,
@@ -47,7 +43,6 @@ class bash::common {
         content => template("${module_name}/bash_aliases.sh.erb"),
     }
 
-    #    file {  [ $bash::params::profile_dir, $bash::params::skel_dir ]:
     file {  $bash::params::skel_dir:
         ensure  => 'directory',
         mode    => $bash::params::configdir_mode,

--- a/metadata.json
+++ b/metadata.json
@@ -23,10 +23,6 @@
     {
       "name": "puppetlabs/concat",
       "version_requirement": ">= 1.2.0 < 8.0.0"
-    },
-    {
-      "name": "unibet-profiled",
-      "version_requirement": ">= 0.1.4 < 1.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
The Puppet module profiled isn't used by this module, except for including the class which ensures the directory /etc/profile.d.

The directory is eventually handled within the class bash::config.